### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #QZCircleSegue
 
-QZCircleSegue is written in Swift and it is a beatiful transition between circular-shapped buttons and your ViewController.
+QZCircleSegue is written in Swift and it is a beautiful transition between circular-shapped buttons and your ViewController.
 With just a few super-simple steps you can setup your settings according to your app.
 
 What it does?


### PR DESCRIPTION
@alextarrago, I've corrected a typographical error in the documentation of the [QZCircleSegue](https://github.com/alextarrago/QZCircleSegue) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
